### PR TITLE
Post a review when configured to do so.

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,4 +59,11 @@ jobs:
         uses: theoremlp/required-reviews@v1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          # Optional: post a review on the PR instead of failing the task when requirements haven't been satisfied
+          # post-review: true
 ```
+
+Note that the post-review option will cause the task to succed, and should be used in concert with:
+
+- requiring a review from the user that runs the action (controlled via the secret passed to the task)
+- requiring the task runs to completion (so that reviews are required for each commit)

--- a/src/main.ts
+++ b/src/main.ts
@@ -197,6 +197,7 @@ export function checkOverride(
 async function run(): Promise<void> {
   try {
     const authToken = core.getInput("github-token");
+    const postReview = core.getInput("post-review") === "true";
     const octokit = github.getOctokit(authToken);
     const context = github.context;
 
@@ -234,12 +235,30 @@ async function run(): Promise<void> {
         reviewersConfig.overrides !== undefined &&
         checkOverride(reviewersConfig.overrides, modifiedFilepaths, committers);
       if (!override) {
-        core.setFailed("Missing required approvals.");
+        if (postReview) {
+          await octokit.rest.pulls.createReview({
+            ...context.repo,
+            pull_number: prNumber,
+            event: "REQUEST_CHANGES",
+            body: "Missing required reviewers",
+          });
+        } else {
+          core.setFailed("Missing required approvals.");
+        }
         return;
       }
+      // drop through
       core.info("Missing required approvals but allowing due to override.");
     }
     // pass
+    if (postReview) {
+      await octokit.rest.pulls.createReview({
+        ...context.repo,
+        pull_number: prNumber,
+        event: "APPROVE",
+        body: "All review requirements have been met",
+      });
+    }
     core.info("All review requirements have been met");
   } catch (error) {
     if (error instanceof Error) {


### PR DESCRIPTION
## Before this PR
The only way to run this check is to fail the check when requirements have not been satisfied.

## After this PR
Add an action option 'post-review' that when set to 'true' will cause this task to post a review to the PR approving when requirements are satisfied or requesting changes when requirements have not been satisfied. When requirements have not been satisfied and a request changes review is posted, the task will still mark itself as succeeded.

Compared to the prior behavior, this will make the PR summary view a little easier to digest.

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

