### PR TITLE
Dismiss approvals rather than requesting changes

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -327,15 +327,13 @@ async function run(): Promise<void> {
           });
         }
       } else {
-        if (
-          lastReview === undefined ||
-          lastReview.state !== "CHANGES_REQUESTED"
-        ) {
-          await octokit.rest.pulls.createReview({
+        // dismiss prior approval by re-requesting
+        if (lastReview !== undefined && lastReview.state == "APPROVED") {
+          await octokit.rest.pulls.dismissReview({
             ...context.repo,
             pull_number: prNumber,
-            event: "REQUEST_CHANGES",
-            body: "Missing required reviewers.",
+            review_id: lastReview.id,
+            message: "Dismissing due to reviewer requirements.",
           });
         }
       }


### PR DESCRIPTION
## Before this PR
This bot requests changes rather than simply not approving.

## After this PR
When review requirements have been failed, dismiss any prior approvals, but do not request changes.

## Possible downsides?
Less strong indication of failing review requirements/relying on any disapprovers instead of CODEOWNERS to narrow who can approve a PR.

