### PR TITLE
Fix releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,12 +26,12 @@ jobs:
           git config --global user.email "${COMMIT_EMAIL}"
           git config --global user.name "${COMMIT_USER}"
 
-          cp action.yml dist
-          cp .gitignore dist
+          git add -f action.yml .gitignore dist
+          git stash --staged
+
           git checkout -f "${BRANCH}"
-          mv dist/action.yml action.yml
-          mv dist/.gitignore .gitignore
-          git add -f dist action.yml
+
+          git checkout stash -- action.yml .gitignore dist
           git commit --allow-empty -m "${MESSAGE}"
           git push origin "${BRANCH}"
           git tag -f -a "${TAG}" -m "${TAG}"


### PR DESCRIPTION
## Before this PR
Releases are ignoring changes to dist because of faulty release logic.

## After this PR
Release logic will ship updates to all of `action.yml`, `.gitignore`, and `dist`.

