### PR TITLE
No approval when reviewers config is empty

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -166,6 +166,11 @@ export function check(
   infoLog: (message: string) => void,
   warnLog: (message: string) => void
 ) {
+  // if there's no configured reviewers, do not approve
+  if (Object.keys(reviewersConfig.reviewers).length == 0) {
+    return false;
+  }
+
   let approved = true;
   const committersSet = new Set(committers);
 


### PR DESCRIPTION
## Before this PR
When the reviewers config is empty `check` results in an approval, and that behavior is unintuitive.

## After this PR
When the reviewers config is empty `check` results in a no-op.

## Possible downsides?
n/a, usage of this action so far has been with non-empty configs.

