### PR TITLE
Do not send a useless message as part of approvals

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -328,7 +328,6 @@ async function run(): Promise<void> {
             ...context.repo,
             pull_number: prNumber,
             event: "APPROVE",
-            body: "All review requirements have been met.",
           });
         }
       } else {


### PR DESCRIPTION
## Before this PR
We landed a useless message as part of the approval body, this takes up space in the PR and doens't add value.

## After this PR
Approvals are sent with an empty body, which will result in a more concise PR timeline.

## Possible downsides?
none

