### PR TITLE
Enable setting review-user-name

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -5,6 +5,9 @@ inputs:
   github-token:
     required: true
     description: A valid GitHub token
+  review-user:
+    required: false
+    description: The name of the reviewing user (set this if providing a GitHub App authn token)
   post-review:
     required: false
     description: Whether to post a review on the PR

--- a/src/main.ts
+++ b/src/main.ts
@@ -143,13 +143,14 @@ async function getLastReview(
   octokit: GitHubApi,
   context: Context,
   prNumber: number,
-  reviewUser?: string
+  reviewUser: string
 ) {
   const currentUserLogin =
-    reviewUser ||
-    (await (
-      await octokit.rest.users.getAuthenticated()
-    ).data.login);
+    reviewUser !== ""
+      ? reviewUser
+      : await (
+          await octokit.rest.users.getAuthenticated()
+        ).data.login;
   const currentReviews = await octokit.rest.pulls.listReviews({
     ...context.repo,
     pull_number: prNumber,
@@ -277,8 +278,7 @@ export function checkOverride(
 async function run(): Promise<void> {
   try {
     const authToken = core.getInput("github-token");
-    const reviewUserIn = core.getInput("review-user");
-    const reviewUser = reviewUserIn === "" ? undefined : reviewUserIn;
+    const reviewUser = core.getInput("review-user");
     const postReview = core.getInput("post-review") === "true";
     const octokit = github.getOctokit(authToken);
     const context = github.context;


### PR DESCRIPTION
## Before this PR
getAuthenticated() seems to fail for a GitHub App authn token.

## After this PR
To enable using GitHub App authn tokens allow explicitly setting the reviewing username.

## Possible downsides?
This is a no-op when the value is unset.

