### PR TITLE
Add PR author as a contributor

### DIFF
--- a/.github/workflows/autosquash.yml
+++ b/.github/workflows/autosquash.yml
@@ -3,7 +3,7 @@ on:
   pull_request:
     types:
       - opened
-      - synchronized
+      - synchronize
       - reopened
       - edited
       - labeled
@@ -21,4 +21,4 @@ jobs:
           squash-commit-title: "${{ github.event.pull_request.title }} (#${{ github.event.pull_request.number }})"
           squash-commit-message: "${{ github.event.pull_request.body }}"
           do-not-merge-label: "do not merge"
-
+          ignore-author: mark-thm


### PR DESCRIPTION
## Before this PR
PR author is not included in the set of committers we check when computing overrides, enabling a bypass of the override for any user capable of creating a PR and setting committer information to be an override user.

## After this PR
Add PR author to the set of users we call 'contributors' (previously 'committers') and use that expanded set to count PR author for override checks.

## Possible downsides?
This is a minor behavior change but it cleans up behavior to match what is expected. As far as I'm aware we're the only users of this action so it shouldn't be an issue.
